### PR TITLE
Persist recommendation

### DIFF
--- a/lib/ex_assignment/application.ex
+++ b/lib/ex_assignment/application.ex
@@ -15,7 +15,9 @@ defmodule ExAssignment.Application do
       # Start the PubSub system
       {Phoenix.PubSub, name: ExAssignment.PubSub},
       # Start the Endpoint (http/https)
-      ExAssignmentWeb.Endpoint
+      ExAssignmentWeb.Endpoint,
+      # Start recomendaation cache
+      ExAssignment.Cache
       # Start a worker by calling: ExAssignment.Worker.start_link(arg)
       # {ExAssignment.Worker, arg}
     ]

--- a/lib/ex_assignment/cache.ex
+++ b/lib/ex_assignment/cache.ex
@@ -5,10 +5,27 @@ defmodule ExAssignment.Cache do
 
 	def start_link(_), do: GenServer.start_link(__MODULE__, [], name: @name)
 
+	def insert() do
+    GenServer.call(@name, :insert)
+  end
+
 	def init(_) do
 		IO.puts("Creating ETS #{@name}")
 
-		:ets.new(:recommendation_keep, [:set, :public, :named_table])
+		:ets.new(:recommendation_keep, [:set, :named_table])
+
+		IO.puts("Inserting initial recommeded todo")
+		handle_call(:insert, nil, %{})
+
     {:ok, "Created"}
 	end
+
+	def handle_call(:insert, _ref, state) do
+		ExAssignment.Todos.list_todos(:open)
+		next_todo = ExAssignment.Todos.generate_next_recommended()
+
+    :ets.insert(:recommendation_keep, {:next_todo, next_todo})
+
+    {:reply, :ok, state}
+  end
 end

--- a/lib/ex_assignment/cache.ex
+++ b/lib/ex_assignment/cache.ex
@@ -1,0 +1,14 @@
+defmodule ExAssignment.Cache do
+	use GenServer
+
+	@name __MODULE__
+
+	def start_link(_), do: GenServer.start_link(__MODULE__, [], name: @name)
+
+	def init(_) do
+		IO.puts("Creating ETS #{@name}")
+
+		:ets.new(:recommendation_keep, [:set, :public, :named_table])
+    {:ok, "Created"}
+	end
+end

--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -127,6 +127,8 @@ defmodule ExAssignment.Todos do
   """
   def delete_todo(%Todo{} = todo) do
     Repo.delete(todo)
+    regenerate_recommended(todo.id)
+    {:ok, todo}
   end
 
   @doc """
@@ -162,12 +164,18 @@ defmodule ExAssignment.Todos do
 
   #checks if the completed todo was recommended and replaces it in cache if so
   defp regenerate_recommended(checked_todo_id) do
+
     current_recommended_todo_id = get_recommended() |> Map.get(:id)
 
-    if current_recommended_todo_id == String.to_integer(checked_todo_id) do #ensure id is always a string
+    if current_recommended_todo_id == unstringify(checked_todo_id) do
       ExAssignment.Cache.insert()
     end
   end
+
+  #converts bitstring id to integer
+  defp unstringify(id) when is_bitstring(id), do: String.to_integer(id)
+  defp unstringify(id), do: id
+
 
   @doc """
   Marks the todo referenced by the given id as unchecked (not done).

--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -191,6 +191,10 @@ defmodule ExAssignment.Todos do
       from(t in Todo, where: t.id == ^id, update: [set: [done: false]])
       |> Repo.update_all([])
 
+    if length(list_todos(:open)) == 1 do
+      ExAssignment.Cache.insert()
+    end
+    
     :ok
   end
 end

--- a/lib/ex_assignment/todos/todo.ex
+++ b/lib/ex_assignment/todos/todo.ex
@@ -15,5 +15,6 @@ defmodule ExAssignment.Todos.Todo do
     todo
     |> cast(attrs, [:title, :priority, :done])
     |> validate_required([:title, :priority, :done])
+    |> unique_constraint([:title])
   end
 end

--- a/priv/repo/migrations/20240802133537_add_title_uniqueness_to_todos.exs
+++ b/priv/repo/migrations/20240802133537_add_title_uniqueness_to_todos.exs
@@ -1,0 +1,7 @@
+defmodule ExAssignment.Repo.Migrations.AddTitleUniquenessToTodos do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:todos, [:title])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,6 +10,8 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
+ExAssignment.Repo.delete_all(ExAssignment.Todos.Todo)
+
 ExAssignment.Repo.insert!(%ExAssignment.Todos.Todo{
   title: "water flowers",
   priority: 60,

--- a/test/ex_assignment/todos_test.exs
+++ b/test/ex_assignment/todos_test.exs
@@ -10,9 +10,15 @@ defmodule ExAssignment.TodosTest do
 
     @invalid_attrs %{done: nil, priority: nil, title: nil}
 
+    setup do
+      #Add a recommended todo to avoid failures for 
+      todo_fixture(%{title: "recommended"})
+      ExAssignment.Cache.insert()
+      :ok
+    end
+
     test "list_todos/0 returns all todos" do
-      todo = todo_fixture()
-      assert Todos.list_todos() == [todo]
+      assert length(Todos.list_todos()) == 1
     end
 
     test "get_todo!/1 returns the todo with given id" do
@@ -51,6 +57,7 @@ defmodule ExAssignment.TodosTest do
 
     test "delete_todo/1 deletes the todo" do
       todo = todo_fixture()
+
       assert {:ok, %Todo{}} = Todos.delete_todo(todo)
       assert_raise Ecto.NoResultsError, fn -> Todos.get_todo!(todo.id) end
     end
@@ -61,12 +68,6 @@ defmodule ExAssignment.TodosTest do
     end
 
     test "get_recommended/0 returns persisted todo" do
-      for _ <- 1..3 do
-        todo_fixture()
-      end
-
-      ExAssignment.Cache.insert() #cache recommended todo
-
       current_recommended_todo = Todos.get_recommended()
 
       #complete a different todo
@@ -74,6 +75,24 @@ defmodule ExAssignment.TodosTest do
       Todos.check("#{todo.id}")
 
       assert Todos.get_recommended() == current_recommended_todo
+    end
+
+    test "get_recommended/0 returns different todo once current is complete" do
+      current_recommended_todo = Todos.get_recommended()
+
+      #complete the currentlt recommended todo
+      Todos.check(current_recommended_todo.id)
+
+      refute Todos.get_recommended() == current_recommended_todo
+    end
+
+    test "get_recommended/0 returns different todo once current is deleted" do
+      current_recommended_todo = Todos.get_recommended()
+
+      #complete the currentlt recommended todo
+      Todos.delete_todo(current_recommended_todo)
+
+      refute Todos.get_recommended() == current_recommended_todo
     end
   end
 end

--- a/test/ex_assignment/todos_test.exs
+++ b/test/ex_assignment/todos_test.exs
@@ -59,5 +59,21 @@ defmodule ExAssignment.TodosTest do
       todo = todo_fixture()
       assert %Ecto.Changeset{} = Todos.change_todo(todo)
     end
+
+    test "get_recommended/0 returns persisted todo" do
+      for _ <- 1..3 do
+        todo_fixture()
+      end
+
+      ExAssignment.Cache.insert() #cache recommended todo
+
+      current_recommended_todo = Todos.get_recommended()
+
+      #complete a different todo
+      todo = todo_fixture()
+      Todos.check("#{todo.id}")
+
+      assert Todos.get_recommended() == current_recommended_todo
+    end
   end
 end

--- a/test/support/fixtures/todos_fixtures.ex
+++ b/test/support/fixtures/todos_fixtures.ex
@@ -11,7 +11,7 @@ defmodule ExAssignment.TodosFixtures do
     {:ok, todo} =
       attrs
       |> Enum.into(%{
-        done: true,
+        done: false,
         priority: 42,
         title: "some title"
       })


### PR DESCRIPTION
### **Exercise 2**

**Achieved on this PR:**

1. Persist current recommended todo using ETS Cache
    - used a dedicated Genserver process to create an ETS table and manage inserts to the cache
    - a new insert to the cache replaces the existent recomendation under the key `next_todo`
    - tested that a recommendation gets persisted through sessions
2. Regenerate a new recommendation and save to the cache at 3 stages:
    - when the current recommended todo is completed
    - when the current recommended todo is deleted
    - And on startup to get the initial recommended todo before any transactions
3. Made Todo titles unique to avoid duplicate todo items

**Hitches**
 - None. Had fun.

![ami-final](https://github.com/user-attachments/assets/80bd44dc-098c-4e67-a971-fd8a590b25d4)
