### PR TITLE
Improve Recommendations and Persist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,132 +1,68 @@
-# Assignment - Todo Recommendations
+### To-do List Recommendations
 
-![AMI Company Logo](.docs/images/logo.svg)
+Grateful for the opportunity to do the case study/ Here is the breakdown of my approach towards the two exercises. Looking forward to discussing it. Kindly note that we will use the `develop` ranch that has changes for both exercises
 
-A small Elixir/Phoenix assignment for the [AMI](https://www.africanmanagers.org/) hiring process.
+**Project Setup**
 
----
+- Ensure you have Elixir 1.14 and Erlang/OTP 25 installed.
+- We recommend using [asdf](https://asdf-vm.com/), in which case you can use the `.tool-versions` file in this repository, to setup your development environment.
+- Next checkout to the `develop` branch to get the latest updates of the task
+- Once your enviroment is prepared, run `mix setup` from the root directory of this repository, to compile the project and initialize the development database.
+- Finally start the Phoenix server with `mix phx.server` or inside IEx with `iex -S mix phx.server`.
 
-Hey there 👋, we are AMI, a tech company from Africa.
-AMI enables ambitious businesses across Africa to thrive. We believe that skilled people build thriving businesses, thriving businesses create quality jobs, and quality jobs drive prosperity and dignity.
----
+- Now you can visit [`http://localhost:4000`](http://localhost:4000) from your browser and interact with the application.
 
-This repository contains a very simple Phoenix application,
-that uses an SQLite3 database for persistence.
+**Implementation**
 
-The application manages a list of Todos.
-Todos can be created, marked as done and finally removed from the list.
-All todos have a priority that represent the urgency of a todo.
+**Exercise 1**
 
-Whenever the user opens the list of Todos,
-the system tries to recommend a todo,
-that should be performed next by the user.
-However, the logic which selects the recommended todo is not very smart (yet).
-It will be your task to improve the todo recommendation logic during this assignment.
+**Managed to do **
 
-![Screenshot: Todos overview](.docs/images/screenshot_todos.png)
+1. Used probability based on todo item priority to recommend the next to do
+2. Used the principle of the lowest priority number being the most urgent
 
-## Getting started
+**Hitches**
 
-> We recommend to fork this repository to your GitHub account before you get started,
-> which makes it much easier to hand in the solution when you are done.
+1. Got the solution working well for the inverse of the principle (high priority number representing high urgency) :(
+2. When trying to tweak the solution I made the algo select the most urgent todo **but** with an 100% probability rate every time, like this:
+    
+![Screenshot from 2024-08-03 19-47-51](https://github.com/user-attachments/assets/496730ad-908c-4c31-81cb-7c4c1bd8e839)
+  -This only means that the chance that `prepare lunch` (highest urgency), will be chosen over and over again is 100%
+  - This may be an issue since my solution was to work on probability and not facts lol
+  - The upside to this is that it actually fixes Exercise 2 without persistence, yes, a nice-to-have bug maybe? We know that the recommendation will always be the same even on browser restarts because of the 100% probability rate, only until we add a more urgent todo though.
+
+3. I did not write tests for this functionality
+
+**Assumptions**
+
+- My assumptions in all this was that recommended todos should always be the most urgent
+
+**Short Demo**
+
+![improvegif](https://github.com/user-attachments/assets/4c92e960-cac3-40ce-abbf-46becf416e6a)
 
 
-Ensure you have Elixir 1.14 and Erlang/OTP 25 installed.
-We recommend using [asdf](https://asdf-vm.com/),
-in which case you can use the `.tool-versions` file in this repository,
-to setup your development environment.
 
-Once your enviroment is prepared, run `mix setup` from the root directory of this repository,
-to compile the project and initialize the development database.
+**Exercise 2**
 
-Finally start the Phoenix server with `mix phx.server` or inside IEx with `iex -S mix phx.server`.
+**Managed to do**
 
-Now you can visit [`http://localhost:4000`](http://localhost:4000) from your browser and interact with the application.
+1. Persist current recommended todo using ETS Cache
+    - used a dedicated Genserver process to create an ETS table and manage inserts to the cache
+    - a new insert to the cache replaces the existent recomendation under the key `next_todo`
+    - tested that a recommendation gets persisted through sessions
+2. Regenerate a new recommendation and save to the cache at 3 stages:
+    - when the current recommended todo is completed
+    - when the current recommended todo is deleted
+    - And on startup to get the initial recommended todo before any transactions
+3. Made Todo titles unique to avoid duplicate todo items(nice-to-have)
 
-> **Note**
-> There is nothing special about this application,
-> so if you get stuck you can always have a look at the [official Phoenix docs](https://hexdocs.pm/phoenix/1.7.1/installation.html).
+**Hitches**
+ - None. Had fun.
+ - Also had to do a hard-reset since I merged the `improve-recommendations` branch locally, hence the announced `force push`
 
-## Assignment
+**Short Demo**
 
-The assignment consists of two exercises, that are functionally related,
-but don't build upon each other.
-For both exercies you have to clone this repository,
-get the application running locally and then work on the code,
-as you would with any other Elixir/Phoenix application.
+![ami-final](https://github.com/user-attachments/assets/25e45e20-1ac9-4ff8-add7-9d5e632e8baa)
 
-### What is and isn't expected
-
-- We don't expect you to complete all exercises.
-The main goal of the assignment is to have some code we can talk about in our next call.
-We don't want to use more of your free time than absolutely necessary.
-The assignment is intended to take **up to 4 hours**, but not more.
-
-- It is up to you which exercise you start with.
-There is no need to do exercise 1 first.
-
-- The application should work out of the box.
-No show-stopper kind of programming errors have been intentionally added to it.
-However, we expect you to **fix any existing application/logic errors** that you may find.
-We would love to discuss them in our next call.
-
-- We expect you to do **local refactorings and small code improvements** as you see fit.
-However, do not focus on the HTML/CSS/JS part of the application, unless absolutely necessary.
-This is an Elixir assignment after all.
-- writing test cases is not must but pls follow whatever your normal programming practice is
-
-- Last but not least we expect you to **use Git** during the assignment.
-Put your changes into appropriately sized commits,
-just as if you were working in a collaborative environment.
-
-### Exercise 1: Improve the quality of 'What should I do next?' recommendations
-
-When opening [`http://localhost:4000/todos`](http://localhost:4000/todos),
-the system displays one of the todos at the top,
-that it recommends to be performed next.
-Currently this todo is selected randomly from the list of open todos.
-
-We would like to continue displaying a randomly selected todo in this spot,
-but the todo should be selected in such a way,
-that todos with a higher urgency also have a higher chance to be recommended.
-
-The probability of a todo to be recommended should correspond to its urgency,
-when compared to the urgency of other todos.
-
-As an example lets consider there are 4 open todos in the list:
-
-- *Prepare lunch* (priority: `20`)
-- *Water flowers* (priority: `50`)
-- *Shop groceries* (priority: `60`)
-- *Buy new flower pots* (priority: `130`)
-
-> **Note**
-> A high urgency is encoded as a lower value in the `priority` field of a todo.
-> For example a todo with a `priority` of `20` is considered to be more urgent than a todo with a `priority` of `50`.
-
-The probability for recommending *Prepare lunch* should be `~2.5` times as high as recommending *Water flowers*, `~3` times as high as *Shop groceries* and `~6.5` times as high as recommending *Buy new flower pots*.
-All other probabilities should follow the same rule.
-
-![Screenshot: What should I do next?](.docs/images/screenshot_what_should_i_do_next.png)
-
-### Exercise 2: Persist the 'What should I do next?' recommendation
-
-Currently the recommended todo changes whenever the page is refreshed.
-From a user perspective this behavior is far from being ideal.
-We want to "generate" a recommended todo and then keep it for some time,
-so it doesn't change when the page is reloaded or the browser window is closed and reopened later.
-However, when the todo is marked done, a new recommendation must be generated if there are any open todos left.
-
-It is up to you how to persist this information.
-You can use the SQLite database, but you don't have to.
-We don't expect the recommendation to be persisted across server restarts.
-
-## Handing in the solution
-
-- If you have forked this repository, ensure you pushed all your changes and then send
-  a link to your forked repository to [HR](mailto:brendawakaba@africanmanagers.org). Also make sure the repository is publicly accessible.
-
-- Alternatively you can send your solution directly by mail to [HR](mailto:brendawakaba@africanmanagers.org),
-for example as a zip archive.
-Please make sure the solution contains the entire project including the `.git` directory,
-so we can have a look at your commits.
+Thats it! Happy coding, or code watching!

--- a/lib/ex_assignment/application.ex
+++ b/lib/ex_assignment/application.ex
@@ -15,7 +15,9 @@ defmodule ExAssignment.Application do
       # Start the PubSub system
       {Phoenix.PubSub, name: ExAssignment.PubSub},
       # Start the Endpoint (http/https)
-      ExAssignmentWeb.Endpoint
+      ExAssignmentWeb.Endpoint,
+      # Start recomendaation cache
+      ExAssignment.Cache
       # Start a worker by calling: ExAssignment.Worker.start_link(arg)
       # {ExAssignment.Worker, arg}
     ]

--- a/lib/ex_assignment/cache.ex
+++ b/lib/ex_assignment/cache.ex
@@ -5,10 +5,27 @@ defmodule ExAssignment.Cache do
 
 	def start_link(_), do: GenServer.start_link(__MODULE__, [], name: @name)
 
+	def insert() do
+    GenServer.call(@name, :insert)
+  end
+
 	def init(_) do
 		IO.puts("Creating ETS #{@name}")
 
-		:ets.new(:recommendation_keep, [:set, :public, :named_table])
+		:ets.new(:recommendation_keep, [:set, :named_table])
+
+		IO.puts("Inserting initial recommeded todo")
+		handle_call(:insert, nil, %{})
+
     {:ok, "Created"}
 	end
+
+	def handle_call(:insert, _ref, state) do
+		ExAssignment.Todos.list_todos(:open)
+		next_todo = ExAssignment.Todos.generate_next_recommended()
+
+    :ets.insert(:recommendation_keep, {:next_todo, next_todo})
+
+    {:reply, :ok, state}
+  end
 end

--- a/lib/ex_assignment/cache.ex
+++ b/lib/ex_assignment/cache.ex
@@ -1,0 +1,14 @@
+defmodule ExAssignment.Cache do
+	use GenServer
+
+	@name __MODULE__
+
+	def start_link(_), do: GenServer.start_link(__MODULE__, [], name: @name)
+
+	def init(_) do
+		IO.puts("Creating ETS #{@name}")
+
+		:ets.new(:recommendation_keep, [:set, :public, :named_table])
+    {:ok, "Created"}
+	end
+end

--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -39,27 +39,6 @@ defmodule ExAssignment.Todos do
     end
   end
 
-  def sum_of_priorities(todos) do
-    todos = Enum.reverse todos
-    value2 = todos |> Enum.reduce(0, fn %{priority: priority}, sum -> priority + sum end) 
-    value = Enum.take_random(1..value2, 1) |> List.first() |> IO.inspect(label: "*********random value*****")
-    choose_todo(todos, value, value2)
-  end
-
-  defp choose_todo([%{title: title}], _, _) do
-    title
-  end
-
-  defp choose_todo([%{title: title, priority: _priority} | t], rand_value, acc) do
-    acc = acc - rand_value
-
-    if rand_value <= acc  do
-      title
-    else
-      choose_todo(t, rand_value, acc)
-    end
-  end
-
   @doc """
   Returns the next todo that is recommended to be done by the system.
 
@@ -69,7 +48,27 @@ defmodule ExAssignment.Todos do
     list_todos(:open)
     |> case do
       [] -> nil
-      todos -> Enum.take_random(todos, 1) |> List.first()
+      todos -> recommend_todo(todos)
+    end
+  end
+
+  #uses probability based on priority to recommend the next todo
+  defp recommend_todo(todos) do
+    randomized_value = todos |> Enum.reduce(0, fn %{priority: priority}, sum -> priority + sum end) |> :rand.uniform()
+    choose_todo(todos, randomized_value, 0)
+  end
+
+  defp choose_todo([todo], _, _), do: todo
+
+  defp choose_todo([todo | t], rand_value, acc) do
+    %{priority: priority} = todo
+
+    acc = acc - priority
+
+    if rand_value >= acc  do
+      todo
+    else
+      choose_todo(t, rand_value, acc)
     end
   end
 

--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -127,6 +127,8 @@ defmodule ExAssignment.Todos do
   """
   def delete_todo(%Todo{} = todo) do
     Repo.delete(todo)
+    regenerate_recommended(todo.id)
+    {:ok, todo}
   end
 
   @doc """
@@ -162,12 +164,18 @@ defmodule ExAssignment.Todos do
 
   #checks if the completed todo was recommended and replaces it in cache if so
   defp regenerate_recommended(checked_todo_id) do
+
     current_recommended_todo_id = get_recommended() |> Map.get(:id)
 
-    if current_recommended_todo_id == String.to_integer(checked_todo_id) do #ensure id is always a string
+    if current_recommended_todo_id == unstringify(checked_todo_id) do
       ExAssignment.Cache.insert()
     end
   end
+
+  #converts bitstring id to integer
+  defp unstringify(id) when is_bitstring(id), do: String.to_integer(id)
+  defp unstringify(id), do: id
+
 
   @doc """
   Marks the todo referenced by the given id as unchecked (not done).

--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -191,6 +191,10 @@ defmodule ExAssignment.Todos do
       from(t in Todo, where: t.id == ^id, update: [set: [done: false]])
       |> Repo.update_all([])
 
+    if length(list_todos(:open)) == 1 do
+      ExAssignment.Cache.insert()
+    end
+    
     :ok
   end
 end

--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -39,6 +39,27 @@ defmodule ExAssignment.Todos do
     end
   end
 
+  def sum_of_priorities(todos) do
+    todos = Enum.reverse todos
+    value2 = todos |> Enum.reduce(0, fn %{priority: priority}, sum -> priority + sum end) 
+    value = Enum.take_random(1..value2, 1) |> List.first() |> IO.inspect(label: "*********random value*****")
+    choose_todo(todos, value, value2)
+  end
+
+  defp choose_todo([%{title: title}], _, _) do
+    title
+  end
+
+  defp choose_todo([%{title: title, priority: _priority} | t], rand_value, acc) do
+    acc = acc - rand_value
+
+    if rand_value <= acc  do
+      title
+    else
+      choose_todo(t, rand_value, acc)
+    end
+  end
+
   @doc """
   Returns the next todo that is recommended to be done by the system.
 

--- a/lib/ex_assignment/todos/todo.ex
+++ b/lib/ex_assignment/todos/todo.ex
@@ -15,5 +15,6 @@ defmodule ExAssignment.Todos.Todo do
     todo
     |> cast(attrs, [:title, :priority, :done])
     |> validate_required([:title, :priority, :done])
+    |> unique_constraint([:title])
   end
 end

--- a/priv/repo/migrations/20240802133537_add_title_uniqueness_to_todos.exs
+++ b/priv/repo/migrations/20240802133537_add_title_uniqueness_to_todos.exs
@@ -1,0 +1,7 @@
+defmodule ExAssignment.Repo.Migrations.AddTitleUniquenessToTodos do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:todos, [:title])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,6 +10,8 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
+ExAssignment.Repo.delete_all(ExAssignment.Todos.Todo)
+
 ExAssignment.Repo.insert!(%ExAssignment.Todos.Todo{
   title: "water flowers",
   priority: 60,

--- a/test/ex_assignment/todos_test.exs
+++ b/test/ex_assignment/todos_test.exs
@@ -10,9 +10,15 @@ defmodule ExAssignment.TodosTest do
 
     @invalid_attrs %{done: nil, priority: nil, title: nil}
 
+    setup do
+      #Add a recommended todo to avoid failures for 
+      todo_fixture(%{title: "recommended"})
+      ExAssignment.Cache.insert()
+      :ok
+    end
+
     test "list_todos/0 returns all todos" do
-      todo = todo_fixture()
-      assert Todos.list_todos() == [todo]
+      assert length(Todos.list_todos()) == 1
     end
 
     test "get_todo!/1 returns the todo with given id" do
@@ -51,6 +57,7 @@ defmodule ExAssignment.TodosTest do
 
     test "delete_todo/1 deletes the todo" do
       todo = todo_fixture()
+
       assert {:ok, %Todo{}} = Todos.delete_todo(todo)
       assert_raise Ecto.NoResultsError, fn -> Todos.get_todo!(todo.id) end
     end
@@ -61,12 +68,6 @@ defmodule ExAssignment.TodosTest do
     end
 
     test "get_recommended/0 returns persisted todo" do
-      for _ <- 1..3 do
-        todo_fixture()
-      end
-
-      ExAssignment.Cache.insert() #cache recommended todo
-
       current_recommended_todo = Todos.get_recommended()
 
       #complete a different todo
@@ -74,6 +75,24 @@ defmodule ExAssignment.TodosTest do
       Todos.check("#{todo.id}")
 
       assert Todos.get_recommended() == current_recommended_todo
+    end
+
+    test "get_recommended/0 returns different todo once current is complete" do
+      current_recommended_todo = Todos.get_recommended()
+
+      #complete the currentlt recommended todo
+      Todos.check(current_recommended_todo.id)
+
+      refute Todos.get_recommended() == current_recommended_todo
+    end
+
+    test "get_recommended/0 returns different todo once current is deleted" do
+      current_recommended_todo = Todos.get_recommended()
+
+      #complete the currentlt recommended todo
+      Todos.delete_todo(current_recommended_todo)
+
+      refute Todos.get_recommended() == current_recommended_todo
     end
   end
 end

--- a/test/ex_assignment/todos_test.exs
+++ b/test/ex_assignment/todos_test.exs
@@ -59,5 +59,21 @@ defmodule ExAssignment.TodosTest do
       todo = todo_fixture()
       assert %Ecto.Changeset{} = Todos.change_todo(todo)
     end
+
+    test "get_recommended/0 returns persisted todo" do
+      for _ <- 1..3 do
+        todo_fixture()
+      end
+
+      ExAssignment.Cache.insert() #cache recommended todo
+
+      current_recommended_todo = Todos.get_recommended()
+
+      #complete a different todo
+      todo = todo_fixture()
+      Todos.check("#{todo.id}")
+
+      assert Todos.get_recommended() == current_recommended_todo
+    end
   end
 end

--- a/test/support/fixtures/todos_fixtures.ex
+++ b/test/support/fixtures/todos_fixtures.ex
@@ -11,7 +11,7 @@ defmodule ExAssignment.TodosFixtures do
     {:ok, todo} =
       attrs
       |> Enum.into(%{
-        done: true,
+        done: false,
         priority: 42,
         title: "some title"
       })


### PR DESCRIPTION
-  Used probability based on todo item priority to recommend the next to do
-  Used the principle of the lowest priority number being the most urgent
-  Persist current recommended todo using ETS Cache
    - used a dedicated Genserver process to create an ETS table and manage inserts to the cache
    - a new insert to the cache replaces the existent recomendation under the key `next_todo`
    - tested that a recommendation gets persisted through sessions
-  Regenerate a new recommendation and save to the cache at 3 stages:
    - when the current recommended todo is completed
    - when the current recommended todo is deleted
    - And on startup to get the initial recommended todo before any transactions
-  Made Todo titles unique to avoid duplicate todo items(nice-to-have)